### PR TITLE
Removed VCF from the list of input formats that BioInterchange can handle

### DIFF
--- a/implementation.tex
+++ b/implementation.tex
@@ -153,7 +153,7 @@ FALDO is already deployed and used in a number of tools and databases.
 \begin{description}
 \item[JBrowse] can use SPARQL queries with FALDO to visualize annotations on reference sequences from semantic databases \cite{JBrowse} (see figure \ref{fig:jbrowse}).
 \item[INSDC-DDBJ] DDBJ is currently working on an RDF format for the INSDC data that is stored in DDBJ/GenBank/EMBL-Bank.
-\item[BioInterchange] uses FALDO to make position information stored in current bioinformatics formats like GFF3, GVF, GTF, or VCF, available to the semantic web (\url{http://www.biointerchange.org/}).
+\item[BioInterchange] uses FALDO to make position information stored in current bioinformatics formats (s.a. GFF3, GTF and GVF) available to the semantic web (\url{http://www.biointerchange.org/}).
 \item[TogoGenome] a genome database collection provided by the DBCLS also uses FALDO in its RDF representation (\url{http://togogenome.org/}).
 \item[InterMine] The popular model organism database software collection uses FALDO in its SPARQL mode \cite{InterMine}.
 \item[PhenomeBrowser] The positions on the mouse genome of phenotype and disease related natural variations are described using FALDO.


### PR DESCRIPTION
VCF RDFization is still work-in-progress.
