### PR TITLE
Updated description section in implementations; updated my affiliation and BioInterchange URI

### DIFF
--- a/implementation.tex
+++ b/implementation.tex
@@ -166,8 +166,8 @@ FALDO is already deployed and used in a number of tools and databases, in each c
 \item[GFVO] The Genomic Feature and Variation Ontology (GFVO) uses FALDO to describe loci on genomic landmarks as well as individual genomic feature positions \cite{GFVO}.
 \item[JBrowse] JBrowse can use SPARQL queries with FALDO to visualize annotations on reference sequences from semantic databases \cite{JBrowse} (see Figure \ref{fig:jbrowse}).
 \item[INSDC-DDBJ] DDBJ is currently working on an RDF format for the INSDC data that is stored in DDBJ/GenBank/EMBL-Bank.
-\item[BioInterchange] makes use of FALDO in its RDF formatted output to describe genomic position information stored in the bioinformatics file formats of GFF3, GTF, GVF and VCF (\url{http://www.codamono.com/biointerchange}).
-\item[TogoGenome] a genome database collection provided by the DBCLS also uses FALDO in its RDF representation (\url{http://togogenome.org/}).
+\item[BioInterchange] BioInterchange makes use of FALDO in its RDF formatted output to describe genomic position information stored in the bioinformatics file formats of GFF3, GTF, GVF and VCF (\url{http://www.codamono.com/biointerchange}).
+\item[TogoGenome] TogoGenome is a genome database collection provided by the DBCLS that uses FALDO in its RDF representation (\url{http://togogenome.org/}).
 %\item[InterMine] The popular model organism database software collection uses FALDO in its SPARQL mode \cite{InterMine}.
 \item[PhenomeBrowser] The positions on the mouse genome of phenotype and disease related natural variations are described using FALDO.
 \item[BOING] The ``bio-ontology integrated querying of sequence annotations'' framework uses FALDO to describe all feature locations \cite{BOING}.

--- a/implementation.tex
+++ b/implementation.tex
@@ -163,9 +163,10 @@ FALDO is already deployed and used in a number of tools and databases, in each c
 \end{figure}
 
 \begin{description}
-\item[JBrowse] can use SPARQL queries with FALDO to visualize annotations on reference sequences from semantic databases \cite{JBrowse} (see Figure \ref{fig:jbrowse}).
+\item[GFVO] The Genomic Feature and Variation Ontology (GFVO) uses FALDO to describe loci on genomic landmarks as well as individual genomic feature positions \cite{GFVO}.
+\item[JBrowse] JBrowse can use SPARQL queries with FALDO to visualize annotations on reference sequences from semantic databases \cite{JBrowse} (see Figure \ref{fig:jbrowse}).
 \item[INSDC-DDBJ] DDBJ is currently working on an RDF format for the INSDC data that is stored in DDBJ/GenBank/EMBL-Bank.
-\item[BioInterchange] uses FALDO to make position information stored in current bioinformatics formats (s.a. GFF3, GTF and GVF) available to the Semantic Web (\url{http://www.biointerchange.org/}).
+\item[BioInterchange] makes use of FALDO in its RDF formatted output to describe genomic position information stored in the bioinformatics file formats of GFF3, GTF, GVF and VCF (\url{http://www.codamono.com/biointerchange}).
 \item[TogoGenome] a genome database collection provided by the DBCLS also uses FALDO in its RDF representation (\url{http://togogenome.org/}).
 %\item[InterMine] The popular model organism database software collection uses FALDO in its SPARQL mode \cite{InterMine}.
 \item[PhenomeBrowser] The positions on the mouse genome of phenotype and disease related natural variations are described using FALDO.

--- a/locations.bib
+++ b/locations.bib
@@ -1,5 +1,18 @@
 %% Saved with string encoding Unicode (UTF-8) 
 
+@article{10.7717/peerj.933,
+ title = {{GFVO}: the Genomic Feature and Variation Ontology},
+ author = {Baran, Joachim and Durgahee, Bibi Sehnaaz Begum and Eilbeck, Karen and Antezana, Erick and Hoehndorf, Robert and Dumontier, Michel},
+ year = {2015},
+ month = {5},
+ volume = {3},
+ pages = {e933},
+ journal = {PeerJ},
+ issn = {2167-8359},
+ url = {https://dx.doi.org/10.7717/peerj.933},
+ doi = {10.7717/peerj.933}
+}
+
 @article{GVF,
 	Author = {Martin G. Reese and Barry Moore and Colin Batchelor and Fidel Salas and Fiona Cunningham and Gabor T. Marth and Lincoln Stein and Paul Flicek and Mark Yandell and Karen Eilbeck},
 	Title = {A standard variation file format for human genome sequences},

--- a/locations.tex
+++ b/locations.tex
@@ -70,7 +70,7 @@
 Servet, 1211 Geneva 4, Switzerland,
  \iid(2) Genomics Division, Lawrence Berkeley National Laboratory, Berkeley, CA, 94720, US,
  \iid(3) CeRSA, Parco Tecnologico Padano, Lodi 26900, Italy,
- \iid(4) Ontario Institute for Cancer Research, 101 College Street, Suite 800, Toronto, Ontario, M5G 0A3, Canada,
+ \iid(4) CODAMONO, 5-121 Marion Street, Toronto, Ontario, M6R 1E6, Canada,
  \iid(5) Stanford Center for Biomedical Informatics Research, 1265 Welch Road, Room X223, Stanford, CA, 94305-5479, US,
  \iid(6) Integrative Biology Program, Istituto Nazionale Genetica Molecolare, Milan, Italy,
  \iid(7) University of California, Berkeley, Berkeley, CA, USA,
@@ -118,7 +118,7 @@ SPARQL, RDF, Semantic Web, standardisation, sequence ontology, annotation, data 
 Jerven Bolleman wrote the basic ontology file and mapping to UniProt RDF and contributed to the text of this article.
 Christopher Mungall added the $\mathtt{Bio::FeatureIO::faldo}$ logic to BioPerl and contributed to the OWL modeling.
 Francesco Strozzi contributed to the Cufflinks RDF converter and wrote the VCF converter that uses FALDO for sequence variations positions.
-Joachim Baran incorporated FALDO into the genomic RDFization implementations of the BioInterchange software.
+Joachim Baran incorporated FALDO into the BioInterchange software as well as the Genomic Feature and Variation Ontology (GFVO).
 Michel Dumontier worked on the general modelling as well as mapping FALDO to SIO as an upper ontology.
 Raoul JP Bonnal adapted BioRuby to match the ontology and wrote the Cufflinks to locations.rdf converter. 
 Robert Buels adapted JBrowse to query SPARQL endpoints that use this format to generate custom tracks. 


### PR DESCRIPTION
As it says:

-  my affiliation has been updated
-  BioInterchange URI has been updated (even though the "old" URI still works too and will be kept for backwards compatibility; also, the Ruby gem is still available of course)
-  GFVO citation added, since it referenced the FALDO pre-print and makes use of FALDO